### PR TITLE
Feat: mfusepy migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ The test system uses:
 
 ## Key Dependencies
 
-- `fusepy`: FUSE bindings for Python
+- `mfusepy`: FUSE bindings for Python (FUSE3 compatible)
 - `pygit2>=1.18.0`: Git operations via libgit2 v1.8.1
 - `atomiclong`: Thread-safe counters
 - `sentry-sdk`: Error reporting (Sentry)

--- a/gitfs/mounter.py
+++ b/gitfs/mounter.py
@@ -17,7 +17,7 @@ import argparse
 import resource
 import sys
 
-from fuse import FUSE
+from mfusepy import FUSE
 from pygit2 import Keypair, RemoteCallbacks, UserPass
 
 from gitfs import __version__

--- a/gitfs/router.py
+++ b/gitfs/router.py
@@ -217,3 +217,68 @@ class Router:
         """
         # Delegate to the regular init method
         return self.init(None)
+
+    def __getattr__(self, operation):
+        """
+        Handle FUSE operations by either returning None for unsupported operations
+        or delegating to the __call__ method for supported operations.
+
+        This method is compatible with mfusepy which expects:
+        - None for unsupported operations (so they can be ignored)
+        - Callable methods for supported operations
+        """
+
+        # Operations that are not supported should return None
+        # so that mfusepy can ignore them completely
+        unsupported_operations = {
+            "bmap",
+            "ioctl",
+            "poll",
+            "flock",
+            "fallocate",
+            "lock",
+            "read_buf",
+        }
+
+        if operation in unsupported_operations:
+            return None
+
+        # For supported FUSE operations, return a callable that delegates to __call__
+        supported_operations = {
+            "getattr",
+            "readdir",
+            "read",
+            "write",
+            "create",
+            "mkdir",
+            "rmdir",
+            "unlink",
+            "rename",
+            "chmod",
+            "chown",
+            "truncate",
+            "open",
+            "release",
+            "fsync",
+            "symlink",
+            "readlink",
+            "link",
+            "mknod",
+            "statfs",
+            "flush",
+            "opendir",
+            "releasedir",
+            "fsyncdir",
+            "access",
+            "getxattr",
+            "listxattr",
+            "removexattr",
+            "setxattr",
+            "utimens",
+        }
+
+        if operation in supported_operations:
+            return lambda *args: self(operation, *args)
+
+        # For any other operation, return None (unsupported)
+        return None

--- a/gitfs/router.py
+++ b/gitfs/router.py
@@ -22,7 +22,7 @@ from errno import ENOSYS
 from grp import getgrnam
 from pwd import getpwnam
 
-from fuse import FUSE, FuseOSError
+from mfusepy import FUSE, FuseOSError
 
 from gitfs.cache import CachedIgnore, lru_cache
 from gitfs.events import fetch, idle, shutting_down
@@ -210,14 +210,10 @@ class Router:
 
         raise ValueError(f"Found no view for '{path}'")
 
-    def __getattr__(self, attr_name):
+    def init_with_config(self, conn_info=None, config=None):
         """
-        It will only be called by the `__init__` method from `fuse.FUSE` to
-        establish which operations will be allowed after mounting the
-        filesystem.
+        Initialize filesystem with configuration.
+        Called by mfusepy during mount process.
         """
-
-        methods = inspect.getmembers(FUSE, predicate=callable)
-        fuse_allowed_methods = {elem[0] for elem in methods}
-
-        return attr_name in fuse_allowed_methods - {"bmap", "lock"}
+        # Delegate to the regular init method
+        return self.init(None)

--- a/gitfs/utils/decorators/not_in.py
+++ b/gitfs/utils/decorators/not_in.py
@@ -17,7 +17,7 @@ import errno
 import inspect
 from functools import wraps
 
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 
 
 class not_in:

--- a/gitfs/utils/decorators/write_operation.py
+++ b/gitfs/utils/decorators/write_operation.py
@@ -16,7 +16,7 @@
 from errno import EROFS
 from functools import wraps
 
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 
 from gitfs.events import fetch_successful, push_successful, sync_done, syncing, writers
 from gitfs.log import log

--- a/gitfs/views/commit.py
+++ b/gitfs/views/commit.py
@@ -16,7 +16,7 @@
 import os
 from errno import ENOENT
 
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 from pygit2 import (
     GIT_FILEMODE_BLOB,
     GIT_FILEMODE_BLOB_EXECUTABLE,

--- a/gitfs/views/current.py
+++ b/gitfs/views/current.py
@@ -17,7 +17,7 @@ import errno
 import os
 import re
 
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 
 from gitfs.events import writers
 from gitfs.log import log

--- a/gitfs/views/history.py
+++ b/gitfs/views/history.py
@@ -18,7 +18,7 @@ import time
 from errno import ENOENT
 from stat import S_IFDIR
 
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 
 from gitfs.log import log
 

--- a/gitfs/views/index.py
+++ b/gitfs/views/index.py
@@ -16,7 +16,7 @@
 from errno import ENOENT
 from stat import S_IFDIR
 
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 
 from .read_only import ReadOnlyView
 

--- a/gitfs/views/passthrough.py
+++ b/gitfs/views/passthrough.py
@@ -17,7 +17,7 @@ import fcntl
 import os
 from errno import EACCES
 
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 
 from .view import View
 

--- a/gitfs/views/read_only.py
+++ b/gitfs/views/read_only.py
@@ -16,7 +16,7 @@
 import os
 from errno import EROFS
 
-from fuse import ENOTSUP, FuseOSError
+from mfusepy import ENOTSUP, FuseOSError
 
 from .view import View
 

--- a/gitfs/views/read_only.py
+++ b/gitfs/views/read_only.py
@@ -33,7 +33,7 @@ class ReadOnlyView(View):
 
         return 0
 
-    def create(self, path, fh):
+    def create(self, path, mode, fi=None):
         raise FuseOSError(EROFS)
 
     def write(self, path, fh):

--- a/gitfs/views/view.py
+++ b/gitfs/views/view.py
@@ -15,7 +15,7 @@
 
 from abc import ABCMeta
 
-from fuse import LoggingMixIn, Operations
+from mfusepy import LoggingMixIn, Operations
 
 
 class View(LoggingMixIn, Operations, metaclass=ABCMeta):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ keywords = ["git", "filesystem", "fuse", "version-control"]
 dependencies = [
     "atomiclong==0.1.1",
     "cffi>=1.15.1",
-    "fusepy==3.0.1",
+    "mfusepy==3.0.0",
     "pycparser>=2.21",
     "pygit2>=1.18.0",
     "sentry-sdk>=1.0.0",

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -249,5 +249,5 @@ class TestRouter:
 
     def test_getattr_special_method(self):
         router, mocks = self.get_new_router()
-        assert router.bmap is False
-        assert router.read is not False
+        assert router.bmap is None
+        assert router.read is not None

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -15,7 +15,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 
 from gitfs.router import Router
 from gitfs.views import CurrentView

--- a/tests/utils/test_not_in.py
+++ b/tests/utils/test_not_in.py
@@ -16,7 +16,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 
 from gitfs.cache import CachedIgnore
 from gitfs.utils.decorators.not_in import not_in

--- a/tests/views/test_commit.py
+++ b/tests/views/test_commit.py
@@ -17,7 +17,7 @@ from stat import S_IFDIR, S_IFREG
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 from pygit2 import GIT_FILEMODE_TREE
 
 from gitfs.views.commit import CommitView

--- a/tests/views/test_current.py
+++ b/tests/views/test_current.py
@@ -18,7 +18,7 @@ from threading import Event
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 
 from gitfs.cache.gitignore import CachedIgnore
 from gitfs.views.current import CurrentView

--- a/tests/views/test_history.py
+++ b/tests/views/test_history.py
@@ -17,7 +17,7 @@ from stat import S_IFDIR
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 
 from gitfs.views.history import HistoryView
 

--- a/tests/views/test_index.py
+++ b/tests/views/test_index.py
@@ -16,7 +16,7 @@
 from stat import S_IFDIR
 
 import pytest
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 
 from gitfs.views.index import IndexView
 

--- a/tests/views/test_passthrough.py
+++ b/tests/views/test_passthrough.py
@@ -17,7 +17,7 @@ import os
 from io import TextIOWrapper
 from unittest.mock import MagicMock, call, patch
 
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 from pytest import raises
 
 from gitfs.views import PassthroughView

--- a/tests/views/test_read_only.py
+++ b/tests/views/test_read_only.py
@@ -16,7 +16,7 @@
 import os
 
 import pytest
-from fuse import FuseOSError
+from mfusepy import FuseOSError
 
 from gitfs.views.read_only import ReadOnlyView
 

--- a/uv.lock
+++ b/uv.lock
@@ -146,12 +146,6 @@ toml = [
 ]
 
 [[package]]
-name = "fusepy"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/0b/4506cb2e831cea4b0214d3625430e921faaa05a7fb520458c75a2dbd2152/fusepy-3.0.1.tar.gz", hash = "sha256:72ff783ec2f43de3ab394e3f7457605bf04c8cf288a2f4068b4cde141d4ee6bd", size = 11519, upload-time = "2018-09-17T00:14:52.666Z" }
-
-[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -169,7 +163,7 @@ source = { editable = "." }
 dependencies = [
     { name = "atomiclong" },
     { name = "cffi" },
-    { name = "fusepy" },
+    { name = "mfusepy" },
     { name = "pycparser" },
     { name = "pygit2" },
     { name = "sentry-sdk" },
@@ -197,7 +191,7 @@ test = [
 requires-dist = [
     { name = "atomiclong", specifier = "==0.1.1" },
     { name = "cffi", specifier = ">=1.15.1" },
-    { name = "fusepy", specifier = "==3.0.1" },
+    { name = "mfusepy", specifier = "==3.0.0" },
     { name = "mkdocs", marker = "extra == 'docs'" },
     { name = "mock", marker = "extra == 'dev'", specifier = "==5.1.0" },
     { name = "mock", marker = "extra == 'test'", specifier = "==5.1.0" },
@@ -299,6 +293,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mfusepy"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/94/c9d5dcba4a6a2b32ba23e22fd13ca08e6f5408420b2dfe42984af22277b6/mfusepy-3.0.0.tar.gz", hash = "sha256:eddade33e427bac9c455464cd0a7d12d63c033255ec6b1e0d6ada143a945c6f2", size = 26823, upload-time = "2025-08-01T14:04:30.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/a7/42c1e998ae2b505fa89f2e92683ac136b21186bf47ef8dea06ab3d646c8b/mfusepy-3.0.0-py3-none-any.whl", hash = "sha256:1f8d487ac2c1138b1642955ef92e253685943c97e6f3f5b0e910ab8e04c6312d", size = 24710, upload-time = "2025-08-01T14:04:28.872Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Migrated the codebase from fusepy to mfusepy for FUSE3 compatibility, updating all imports and fixing operation delegation to match mfusepy's requirements.

- **Refactors**
  - Replaced all fusepy imports with mfusepy.
  - Updated Router to return callables or None for FUSE operations as expected by mfusepy.
  - Fixed method signatures and tests to align with mfusepy behavior.

<!-- End of auto-generated description by cubic. -->

